### PR TITLE
Fix build

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -13,7 +13,7 @@ if not app.debug:
 
 # we'll use this handle to db to check collections
 # this app can serve.
-import pymongo
+import pymongo # NOQA
 client = pymongo.MongoClient(app.config['MONGO_URI'])
 db = client.get_default_database()
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -10,4 +10,4 @@ pymongo==2.7.2
 PyYAML==3.11
 Flask-WTF==0.11
 requests==2.5.1
-git+https://github.com/openregister/entry#egg=openregister-entry
+git+https://github.com/openregister/openregister-python@v0.3.0#egg=openregister-entry

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,8 +30,7 @@ def setup():
 
 
 def teardown():
-    collection = db['testing']
-    collection.remove()
+    db.drop_collection('testing')
 
 
 def test_get_unknown_domain_404():


### PR DESCRIPTION
Specifically pin the version of `openregister-python` (previously
`openregister-entry`) that we require. I've chosen this version fairly
arbitrarily as being a version that was released at a similar time to
when `openregister-flask` was last worked on.

It appears as though the method signatures have changed significantly
enough that using the latest version of `openregister-python` is not
simple. At the very least this change makes the build green.